### PR TITLE
feat: drag-to-reorder tasks with smooth sliding animation

### DIFF
--- a/src/columns.js
+++ b/src/columns.js
@@ -13,7 +13,8 @@ import {
   addTask,
   getState,
   getSelectedPath,
-  updateTaskText
+  updateTaskText,
+  reorderTask
 } from './store.js';
 
 import { enterEditMode, isEditing } from './editor.js';
@@ -23,6 +24,8 @@ import { getSettings } from './settings.js';
 let columnsContainer = null;
 let focusedColumn = 0;
 let focusedIndex = 0;
+let dragState = null;     // { taskId, columnIndex, itemIndex }
+let justDroppedId = null; // task id that just landed, cleared after animation
 
 // Track previous ring state so we can animate from old → new values
 // Map<taskId, { offset: number, percent: number, remaining: number }>
@@ -165,6 +168,7 @@ function createTaskElement(task, columnIndex, itemIndex, selectedId) {
   if (focusedColumn === columnIndex && focusedIndex === itemIndex) {
     item.classList.add('focused');
   }
+  if (task.id === justDroppedId) item.classList.add('just-landed');
 
   const group = isTaskGroup(task);
 
@@ -229,6 +233,111 @@ function createTaskElement(task, columnIndex, itemIndex, selectedId) {
     } else {
       selectTask(task.id, columnIndex);
     }
+  });
+
+  // Drag and drop — item itself moves, idle items slide out of the way
+  item.addEventListener('pointerdown', (e) => {
+    if (e.button !== 0) return;
+    if (e.target.closest('.task-checkbox, .task-indicator, button')) return;
+
+    const startY = e.clientY;
+    const columnEl = columnsContainer.querySelector(`.column[data-column-index="${columnIndex}"]`);
+    const allItems = [...columnEl.querySelectorAll('.task-item')];
+    const myIdx = allItems.indexOf(item);
+    if (myIdx === -1) return;
+
+    // Snapshot vertical centers of every item before any movement
+    const originalCenters = allItems.map(el => {
+      const r = el.getBoundingClientRect();
+      return r.top + r.height / 2;
+    });
+    // Height of one slot (item height + 2px margin gap)
+    const slotH = item.offsetHeight + 2;
+
+    let active = false;
+    let currentSlot = myIdx;
+
+    const onMove = (e) => {
+      const dy = e.clientY - startY;
+
+      if (!active) {
+        if (Math.abs(dy) < 6) return;
+        active = true;
+        dragState = { taskId: task.id, columnIndex, itemIndex };
+        item.classList.add('dragging');
+        item.style.zIndex = '100';
+        // Prime idle items for smooth transitions
+        allItems.forEach((el, i) => {
+          if (i !== myIdx) {
+            el.style.willChange = 'transform';
+            el.style.transition = 'transform 0.2s cubic-bezier(0.2, 0, 0, 1)';
+          }
+        });
+      }
+
+      // Dragged item follows cursor directly — no transition
+      item.style.transform = `translateY(${dy}px)`;
+
+      // Where is the dragged item's centre right now?
+      const draggedCenter = originalCenters[myIdx] + dy;
+
+      // Slide idle items to make room and count how many remain above
+      let slot = 0;
+      allItems.forEach((el, i) => {
+        if (i === myIdx) return;
+        const isAbove = i < myIdx;
+        const center  = originalCenters[i];
+        let shifted;
+        if (isAbove) {
+          // Originally above: slide DOWN when dragged item passes above them
+          shifted = draggedCenter < center;
+          el.style.transform = shifted ? `translateY(${slotH}px)` : 'translateY(0)';
+          if (!shifted) slot++; // still above the dragged item
+        } else {
+          // Originally below: slide UP when dragged item passes below them
+          shifted = draggedCenter > center;
+          el.style.transform = shifted ? `translateY(-${slotH}px)` : 'translateY(0)';
+          if (shifted) slot++;  // now above the dragged item
+        }
+      });
+      currentSlot = slot;
+    };
+
+    const cleanup = () => {
+      allItems.forEach(el => {
+        el.style.willChange  = '';
+        el.style.transition  = '';
+        el.style.transform   = '';
+      });
+      item.classList.remove('dragging');
+      item.style.zIndex    = '';
+      item.style.transform = '';
+    };
+
+    const onUp = () => {
+      document.removeEventListener('pointermove', onMove);
+      document.removeEventListener('pointerup',   onUp);
+      document.removeEventListener('pointercancel', onUp);
+
+      if (!active) return;
+      active = false;
+      dragState = null;
+      cleanup();
+
+      if (currentSlot !== myIdx) {
+        justDroppedId = task.id;
+        setTimeout(() => { justDroppedId = null; }, 600);
+        // currentSlot is the final index; translate to reorderTask's targetIndex
+        const targetIndex = currentSlot > myIdx ? currentSlot + 1 : currentSlot;
+        reorderTask(task.id, targetIndex);
+        focusedColumn = columnIndex;
+        focusedIndex  = currentSlot;
+      }
+    };
+
+    document.addEventListener('pointermove', onMove);
+    document.addEventListener('pointerup',   onUp);
+    document.addEventListener('pointercancel', onUp);
   });
 
   return item;

--- a/src/store.js
+++ b/src/store.js
@@ -211,6 +211,17 @@ export function moveTask(id, direction) {
   emit();
 }
 
+export function reorderTask(id, targetIndex) {
+  const siblings = getSiblings(id);
+  const oldIndex = siblings.findIndex(n => n.id === id);
+  if (oldIndex === -1) return;
+  const [task] = siblings.splice(oldIndex, 1);
+  let insertAt = oldIndex < targetIndex ? targetIndex - 1 : targetIndex;
+  insertAt = Math.max(0, Math.min(insertAt, siblings.length));
+  siblings.splice(insertAt, 0, task);
+  emit();
+}
+
 export function indentTask(id) {
   // Make this task a child of the task above it
   const siblings = getSiblings(id);

--- a/style.css
+++ b/style.css
@@ -357,6 +357,8 @@ body {
   gap: 9px;
   border-radius: var(--radius-md);
   cursor: pointer;
+  user-select: none;
+  -webkit-user-select: none;
   transition: background var(--transition-fast), border-color var(--transition-fast), box-shadow var(--transition-fast);
   border: 1px solid transparent;
   position: relative;
@@ -397,6 +399,31 @@ body {
   0%   { background: var(--bg-task); }
   25%  { background: rgba(106, 191, 105, 0.12); border-color: rgba(106, 191, 105, 0.3); }
   100% { background: var(--bg-task); border-color: transparent; }
+}
+
+/* ─── Drag and Drop ──────────────────────────────────── */
+
+/* Dragged item lifts up — no ghost, the item itself moves */
+.task-item.dragging {
+  cursor: grabbing;
+  box-shadow:
+    0 14px 40px rgba(0, 0, 0, 0.6),
+    0 4px 14px rgba(0, 0, 0, 0.4),
+    0 0 0 1px rgba(201, 168, 76, 0.28);
+  background: #252729 !important;
+  border-color: rgba(201, 168, 76, 0.3) !important;
+  /* No transition on transform — must track cursor instantly */
+  transition: box-shadow 0.15s ease, border-color 0.15s ease, background 0.15s ease !important;
+}
+
+/* Task lands — brief amber flash */
+.task-item.just-landed {
+  animation: landFlash 0.5s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@keyframes landFlash {
+  0%   { background: rgba(201, 168, 76, 0.16); border-color: rgba(201, 168, 76, 0.45); }
+  100% { background: transparent; border-color: transparent; }
 }
 
 /* ─── Task Indicator ─────────────────────────────────── */


### PR DESCRIPTION
## Summary

- Replaces HTML5 Drag API with pointer events for full animation control
- Dragged item moves with the cursor via `translateY`; idle items slide out of the way using `transition: transform 0.2s cubic-bezier(0.2,0,0,1)` — no ghost element, no flicker
- Adds `reorderTask()` to `store.js` for arbitrary index reordering
- Dropped item flashes amber on landing via `just-landed` animation
- `user-select: none` on task items prevents text selection while dragging

## Test plan

- [ ] Drag a task up and down — items should slide apart smoothly
- [ ] Drop at a new position — item should flash amber and stay in place
- [ ] Drop back at the same position — no reorder, no flash
- [ ] Click (no drag) still selects/navigates as before
- [ ] Checkbox and progress ring clicks do not start a drag

🤖 Generated with [Claude Code](https://claude.com/claude-code)