### PR TITLE
feat: improve click navigation and child task creation

### DIFF
--- a/src/columns.js
+++ b/src/columns.js
@@ -228,10 +228,10 @@ function createTaskElement(task, columnIndex, itemIndex, selectedId) {
   item.addEventListener('click', () => {
     focusedColumn = columnIndex;
     focusedIndex = itemIndex;
+    selectTask(task.id, columnIndex);
     if (group) {
-      selectTask(task.id, columnIndex);
-    } else {
-      selectTask(task.id, columnIndex);
+      focusedColumn++;
+      focusedIndex = 0;
     }
   });
 
@@ -563,7 +563,24 @@ export function deleteFocusedTask() {
 
 export function addTaskToFocusedColumn() {
   const path = getSelectedPath();
-  const parentId = focusedColumn > 0 ? path[focusedColumn - 1] : null;
+  const focusedTask = getColumnTasks(focusedColumn)[focusedIndex];
+
+  // If the focused task is the selected task, add as its child (even if it has no children yet)
+  const lastSelectedId = path[path.length - 1];
+  let parentId;
+  if (focusedTask && focusedTask.id === lastSelectedId) {
+    parentId = focusedTask.id;
+    const node = addTask(parentId, '');
+    focusedColumn++;
+    focusedIndex = 0;
+    requestAnimationFrame(() => {
+      const el = columnsContainer.querySelector(`.task-item[data-task-id="${node.id}"] .task-text`);
+      if (el) startInlineRename(node.id, el);
+    });
+    return;
+  }
+
+  parentId = focusedColumn > 0 ? path[focusedColumn - 1] : null;
   const node = addTask(parentId, '');
   const tasks = getColumnTasks(focusedColumn);
   focusedIndex = tasks.length - 1;


### PR DESCRIPTION
## Summary
- Clicking a group task now immediately advances `focusedColumn` into its children column (consistent UX with keyboard navigation)
- Pressing `N` when the focused task is the currently selected group now creates the new task as a child of that group, not a sibling

## Test plan
- [ ] Click a group task → verify focus moves into its children column
- [ ] Navigate to a group task with keyboard, press `N` → verify new task is created as a child
- [ ] Press `N` on a non-selected task → verify new task is still added as a sibling in the same column

🤖 Generated with [Claude Code](https://claude.com/claude-code)