### PR TITLE
feat: add light/dark/auto theme toggle

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -4,12 +4,14 @@ const STORAGE_KEY = 'columns-settings';
 
 const DEFAULTS = {
   showCountInRing: false,
+  theme: 'dark',
 };
 
 // ─── State ────────────────────────────────────────────────
 
 let settings = { ...DEFAULTS };
 let settingsListeners = [];
+let autoMql = null;   // stored matchMedia listener for 'auto' theme
 let panelEl = null;
 let backdropEl = null;
 let _isOpen = false;
@@ -26,7 +28,33 @@ let _isOpen = false;
   } catch (e) {
     // ignore parse errors, use defaults
   }
+  applyTheme();
 })();
+
+// ─── Theme ───────────────────────────────────────────
+
+function applyTheme() {
+  // Clean up previous auto listener
+  if (autoMql) {
+    autoMql.mql.removeEventListener('change', autoMql.handler);
+    autoMql = null;
+  }
+
+  const theme = settings.theme || 'dark';
+
+  if (theme === 'auto') {
+    const mql = window.matchMedia('(prefers-color-scheme: light)');
+    const handler = (e) => {
+      document.documentElement.dataset.theme = e.matches ? 'light' : 'dark';
+    };
+    // Apply immediately
+    document.documentElement.dataset.theme = mql.matches ? 'light' : 'dark';
+    mql.addEventListener('change', handler);
+    autoMql = { mql, handler };
+  } else {
+    document.documentElement.dataset.theme = theme;
+  }
+}
 
 // ─── Public API ───────────────────────────────────────────
 
@@ -41,6 +69,7 @@ export function setSetting(key, value) {
   } catch (e) {
     // ignore storage errors
   }
+  if (key === 'theme') applyTheme();
   settingsListeners.forEach(fn => fn(settings));
 }
 
@@ -89,6 +118,21 @@ export function initSettings(appEl) {
           </div>
         </label>
       </div>
+      <div class="settings-divider"></div>
+      <div class="settings-section">
+        <div class="settings-section-label">Appearance</div>
+        <div class="settings-row">
+          <div class="settings-row-text">
+            <span class="settings-row-label">Theme</span>
+            <span class="settings-row-desc">Choose light, dark, or match your system</span>
+          </div>
+          <div class="theme-picker" id="theme-picker">
+            <button class="theme-btn ${settings.theme === 'light' ? 'active' : ''}" data-theme="light">Light</button>
+            <button class="theme-btn ${settings.theme === 'dark' ? 'active' : ''}" data-theme="dark">Dark</button>
+            <button class="theme-btn ${settings.theme === 'auto' ? 'active' : ''}" data-theme="auto">Auto</button>
+          </div>
+        </div>
+      </div>
     </div>
   `;
 
@@ -106,6 +150,16 @@ export function initSettings(appEl) {
   toggle.addEventListener('click', activateToggle);
   toggle.addEventListener('keydown', (e) => {
     if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); activateToggle(); }
+  });
+
+  // Theme picker interaction
+  const themePicker = panelEl.querySelector('#theme-picker');
+  themePicker.addEventListener('click', (e) => {
+    const btn = e.target.closest('[data-theme]');
+    if (!btn) return;
+    const theme = btn.dataset.theme;
+    setSetting('theme', theme);
+    themePicker.querySelectorAll('.theme-btn').forEach(b => b.classList.toggle('active', b.dataset.theme === theme));
   });
 
   appEl.appendChild(backdropEl);

--- a/style.css
+++ b/style.css
@@ -54,6 +54,40 @@
   --stripe: 3px;
 }
 
+/* ─── Light Theme ───────────────────────────────────── */
+
+html[data-theme="light"] {
+  --bg-app:             #eeebe5;
+  --bg-header:          #e6e2db;
+  --bg-column:          #f8f6f2;
+  --bg-column-header:   #f0ede8;
+  --bg-task:            #f8f6f2;
+  --bg-task-hover:      #edeade;
+  --bg-task-selected:   #e8e5d4;
+  --bg-task-focused:    #eae8d4;
+  --color-text:           #1c1a17;
+  --color-text-secondary: #6b6452;
+  --color-text-muted:     #a09880;
+  --color-text-done:      #b8b0a0;
+  --color-accent:       #b8922e;
+  --color-accent-dim:   #9a7825;
+  --color-accent-glow:  rgba(184, 146, 46, 0.14);
+  --color-success:      #3d8c3c;
+  --color-danger:       #b83232;
+  --color-ring-bg:      #d8d4cc;
+  --border-subtle:      #d8d4ca;
+  --border-column:      #cac6be;
+  --border-task:        #d4d0c8;
+  --border-accent:      rgba(184, 146, 46, 0.4);
+  --shadow-column:      0 2px 12px rgba(0, 0, 0, 0.06), 0 0 0 1px rgba(0,0,0,0.04);
+  --shadow-task-focus:  0 0 0 1px var(--border-accent), 0 2px 8px var(--color-accent-glow);
+  --shadow-task-selected: 0 0 0 1px rgba(184, 146, 46, 0.25);
+}
+
+html[data-theme="light"] .task-item.dragging {
+  background: #e8e4dc !important;
+}
+
 /* ─── Noise texture via SVG filter ───────────────────── */
 
 body::before {
@@ -461,7 +495,7 @@ body {
 }
 
 .task-checkbox.checked svg {
-  stroke: #0e0f0f;
+  stroke: var(--bg-app);
 }
 
 /* ─── Progress Ring ──────────────────────────────────── */
@@ -1019,6 +1053,51 @@ body {
 .settings-toggle.on .settings-toggle-thumb {
   transform: translateX(14px);
   background: var(--color-accent);
+}
+
+/* ─── Settings Divider ───────────────────────────────── */
+
+.settings-divider {
+  height: 1px;
+  background: var(--border-subtle);
+  margin: 2px 14px 6px;
+}
+
+/* ─── Theme Picker ───────────────────────────────────── */
+
+.theme-picker {
+  display: flex;
+  gap: 2px;
+  background: var(--bg-app);
+  border: 1px solid var(--border-column);
+  border-radius: var(--radius-sm);
+  padding: 2px;
+  flex-shrink: 0;
+}
+
+.theme-btn {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 3px 8px;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-xs);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.theme-btn:hover {
+  color: var(--color-text-secondary);
+  background: var(--bg-task-hover);
+}
+
+.theme-btn.active {
+  background: rgba(201, 168, 76, 0.14);
+  color: var(--color-accent);
 }
 
 /* ─── Progress Ring Count Text ───────────────────────── */


### PR DESCRIPTION
## Summary

- Adds a three-way theme picker (Light / Dark / Auto) in the Settings panel under a new Appearance section
- Auto mode follows `prefers-color-scheme` and reacts to live OS changes
- Theme is applied immediately on module load to prevent flash of unstyled content (FOUC)
- Preference persists in `localStorage` alongside existing settings

## Test plan

- [ ] Open Settings, verify Light / Dark / Auto buttons appear under Appearance
- [ ] Switch to Light — app renders with warm cream palette
- [ ] Switch to Dark — app returns to dark charcoal palette
- [ ] Switch to Auto — app matches OS theme; changing OS theme updates the app live
- [ ] Reload page — selected theme is restored from localStorage
- [ ] Verify checkboxes, progress rings, drag states, and editor overlay all render correctly in light mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)